### PR TITLE
Add documentation for definitionstab customization

### DIFF
--- a/docs/PxWeb2/documentation/customization.md
+++ b/docs/PxWeb2/documentation/customization.md
@@ -15,6 +15,7 @@ You can:
 - Limit table sizes.
 - Control how and where languages appear in URLs.
 - Hide variables from the variable filter.
+- Customize Definitions panel content. WIP
 - Customize start page text and footer links (examples included below).
 - Define characters used for missing values.
 
@@ -462,6 +463,15 @@ Edit these CSS variables in `theme/variables.css`:
 
 Do not alter `--px-border-radius-none` or `--px-border-radius-full` unless you
 know the side effects (they are used for logical extremes).
+
+### Customize Definitions panel content WIP
+
+The Definitions panel in the right sidebar on the table page, can be
+customized by changing translation strings in the "presentation_page.main_content.about_table.definitions" section of the relevant `locales/<lang>/translation.json` file.
+
+If the strings inside the "about_statistics" and "metadata" sections are empty, the Definitions panel will only show the primary links from the API. The keys inside the "about_statistics" will add a header and text description to the primary links section.
+
+If the API also returns variable definitions, the keys inside the "metadata" section will add a header and text description to the variable definitions section.
 
 ### Change the text and related links on the startpage, table page and in the footer
 

--- a/docs/PxWeb2/documentation/customization.md
+++ b/docs/PxWeb2/documentation/customization.md
@@ -15,7 +15,7 @@ You can:
 - Limit table sizes.
 - Control how and where languages appear in URLs.
 - Hide variables from the variable filter.
-- Customize Definitions panel content. WIP
+- Customize Definitions panel content.
 - Customize start page text and footer links (examples included below).
 - Define characters used for missing values.
 
@@ -464,7 +464,7 @@ Edit these CSS variables in `theme/variables.css`:
 Do not alter `--px-border-radius-none` or `--px-border-radius-full` unless you
 know the side effects (they are used for logical extremes).
 
-### Customize Definitions panel content WIP
+### Customize Definitions panel content
 
 The Definitions panel in the right sidebar on the table page, can be
 customized by changing translation strings in the "presentation_page.main_content.about_table.definitions" section of the relevant `locales/<lang>/translation.json` file.


### PR DESCRIPTION
Adds the documentation for the definitions tab, and how to customize it.

This PR needs to be updated when the API call has been implemented and added to both the API and PxWeb2.